### PR TITLE
add default region is 1(Taipei)

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,6 +87,9 @@ function get_formated_rent_info(search_sheet, rent_result) {
 
 function get_region_from_query(query) {
   let reg_exp = new RegExp(".*region=([0-9]*).*", "gi");
+  if(reg_exp.test(query) === false){
+    return 1 // default is Taipei;
+  }
   let region_number = reg_exp.exec(query)[1];
 
   return region_number;


### PR DESCRIPTION
根據 iThome 裡面的回應(如圖)
![image](https://user-images.githubusercontent.com/25481148/189703287-5a5346aa-e55c-4284-839d-29f3f5d16659.png)
其實不是他複製錯誤而是 591 的搜尋機制所產生的
其發生的機制是 region 預設為 1，591 是不會帶的(如圖)，這會導致原本就要找台北房子的人出現上面留言中的錯誤
![image](https://user-images.githubusercontent.com/25481148/189703647-4ab8746c-666a-4b74-aa2a-fdc55ab176c3.png)
如果要讓 region 被帶入 query 之中就必須在搜尋的時候選擇台北(如圖)
![image](https://i.imgur.com/X2FOkqn.png)
為了避免出現這個錯誤，所以在擷取 query 時新增預設帶入的 region code (1)

