### PR TITLE
fix: RegExp.test g change lastIndex error

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,6 +90,7 @@ function get_region_from_query(query) {
   if(reg_exp.test(query) === false){
     return 1 // default is Taipei;
   }
+  reg_exp.lastIndex = 0;
   let region_number = reg_exp.exec(query)[1];
 
   return region_number;


### PR DESCRIPTION
RegExp 是全域的，會修改到 lastIndex
導致執行完 test() 之後，下一個 exec() 會從 test() 修改後的 lastIndex 開始找尋

![image](https://user-images.githubusercontent.com/61728989/192428647-1b4789d4-d58e-4dff-bb27-88d0d6c9922c.png)

所以將 lastIndex 指回0

![image](https://user-images.githubusercontent.com/61728989/192457403-d3acdf64-1a4c-4caf-a4e0-8359e078196c.png)

